### PR TITLE
feat: default sorting of lbe results by pubyear

### DIFF
--- a/src/components/LeadByExample.js
+++ b/src/components/LeadByExample.js
@@ -115,6 +115,10 @@ function Lbe() {
 		}
 	}
 
+	if (lbeState.switch !== "search") {
+		result.sort((a, b) => b.pubyear - a.pubyear);
+	  }
+
 	return (
 		<div className="lbe">
 			<FilterSection {...{repos, subdiscs, journals, lbeState, setLbeState, resultOutput}} />


### PR DESCRIPTION
I added some lines of code to sort the results at the [lbe dataset page](https://knowledgebase.nfdi4chem.de/knowledge_base/docs/datasets/) by the pubyear of the journal articles. This closes #329 